### PR TITLE
Fix replacing frame-ancestors when missing semicolon

### DIFF
--- a/background.js
+++ b/background.js
@@ -23,7 +23,7 @@ function setHeader(e) {
     }
     else if(header.name.toLowerCase() === "content-security-policy")
     {
-      header.value = header.value.replace(/frame-ancestors.*?;/, "frame-ancestors http://*  https://*;")
+      header.value = header.value.replace(/frame-ancestors[^;]*;?/, "frame-ancestors http://* https://*;")
     }
   }
   var myHeader = {


### PR DESCRIPTION
Existing fix of #2 does not support cases when `frame-ancestors` is only one directive in the `Content-Security-Policy` header and there is missing semicolon in the corresponding header value.

For example:

```
Content-Security-Policy: frame-ancestors http://example.com http://example2.com
```

My PM supports all these cases:

```
Content-Security-Policy: frame-ancestors http://example.com http://example2.com
Content-Security-Policy: frame-ancestors http://example.com http://example2.com;
Content-Security-Policy: anything-else http://example.com; frame-ancestors http://example.com http://example2.com
Content-Security-Policy: anything-else http://example.com; frame-ancestors http://example.com http://example2.com;
Content-Security-Policy: frame-ancestors http://example.com http://example2.com; anything-else http://example.com;
Content-Security-Policy: anything-else http://example.com; frame-ancestors http://example.com http://example2.com; anything-else http://example.com;
```