### PR TITLE
Use originUrl for objects with no frameId.

### DIFF
--- a/background.js
+++ b/background.js
@@ -30,9 +30,29 @@ function updateRegexpes()
 function setHeader(e) {
 	return new Promise((resolve, reject)=>
 	{
-		browser.webNavigation.getFrame({tabId:e.tabId,frameId:e.parentFrameId})
-		.then(parentFrame=>{
-			if(parentFrame.url.match(theRegex))
+		var getEmbedderUrl;
+
+		if (e.type === "object" && e.tabId == -1)
+		{
+			getEmbedderUrl = new Promise((resolve, reject)=>
+			{
+				resolve(e.originUrl);
+			});
+		}
+		else
+		{
+			getEmbedderUrl = new Promise((resolve, reject)=>
+			{
+				browser.webNavigation.getFrame({tabId:e.tabId,frameId:e.parentFrameId})
+				.then(parentFrame=>
+				{
+					resolve(parentFrame.url);
+				});
+			});
+		}
+
+		getEmbedderUrl.then(url=>{
+			if(url.match(theRegex))
 			{
 				e.responseHeaders=e.responseHeaders.filter(x=>(headersdo[x.name.toLowerCase()]||Array)())
 			}


### PR DESCRIPTION
```
onHeadersReceived::tabId is broken for embedded objects and has the
value of -1 ("the request isn't related to a tab"). This breaks the
current embedder url filtering logic that tries to use
webNavigation::getFrame with the out-of-range tabId.

This commit adds a workaround to the particular case and uses
originUrl instead of getFrame->parent->url.

Fixes Adobe Flash embedding on https://boards.4chan.org/f/
```

fixes #16